### PR TITLE
additional .gitignore to exclude cmake build artifacts in VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .idea/
 cmake-build-debug/
 
+# Build results
+build/
+
 # VS Code files for those working on multiple tools
 .vscode/
 # !.vscode/settings.json


### PR DESCRIPTION
VSCode uses a different approach to create build artifacts.
CLion uses cmake_build_*
VSCode uses build

This pull request takes care that VSCode users (me :) ) don't accidently commit builds

- 1 change to .gitignore
- I synced the fork before comitting.
