### PR TITLE
I2c port selectable outside source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,9 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         )
 
 # if environment variable I2C_PORT_SELECTED declared, pass it on to the compiler
+if(DEFINED ENV{I2C_PORT_SELECTED})
 target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE I2C_PORT_SELECTED=$ENV{I2C_PORT_SELECTED})
+endif()
 
 # adjust to enable stdio via usb, or uart
 pico_enable_stdio_usb(${CMAKE_PROJECT_NAME} 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         hardware_i2c
         )
 
+# if environment variable I2C_PORT_SELECTED declared, pass it on to the compiler
+target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE I2C_PORT_SELECTED=$ENV{I2C_PORT_SELECTED})
+
 # adjust to enable stdio via usb, or uart
 pico_enable_stdio_usb(${CMAKE_PROJECT_NAME} 1)
 pico_enable_stdio_uart(${CMAKE_PROJECT_NAME} 0)

--- a/main.cpp
+++ b/main.cpp
@@ -31,7 +31,7 @@
 // set this value to 0 or 1 depending on 0-ohm resistor positions on ADC board.
 // set the value to 0 if the resistors are at the I2C0 labeled position,
 // set the value to 1 if the resistors are at the unlabeled position (which will be I2C1)
-// if the user did not set a sselection, select I2C1 (shabaz solder instructions default)
+// if the user did not set a selection, select I2C1 (shabaz solder instructions default)
 #ifndef I2C_PORT_SELECTED
 #define I2C_PORT_SELECTED 1
 #endif // I2C_PORT_SELECTED

--- a/main.cpp
+++ b/main.cpp
@@ -31,7 +31,9 @@
 // set this value to 0 or 1 depending on 0-ohm resistor positions on ADC board.
 // set the value to 0 if the resistors are at the I2C0 labeled position,
 // set the value to 1 if the resistors are at the unlabeled position (which will be I2C1)
-#define I2C_PORT_SELECTED 1
+#ifndef I2C_PORT_SELECTED
+#define I2C_PORT_SELECTED 0
+#endif // I2C_PORT_SELECTED
 // these pins are supported by the ADC board:
 #define I2C_SDA0_PIN 4
 #define I2C_SCL0_PIN 5

--- a/main.cpp
+++ b/main.cpp
@@ -31,8 +31,9 @@
 // set this value to 0 or 1 depending on 0-ohm resistor positions on ADC board.
 // set the value to 0 if the resistors are at the I2C0 labeled position,
 // set the value to 1 if the resistors are at the unlabeled position (which will be I2C1)
+// if the user did not set a sselection, select I2C1 (shabaz solder instructions default)
 #ifndef I2C_PORT_SELECTED
-#define I2C_PORT_SELECTED 0
+#define I2C_PORT_SELECTED 1
 #endif // I2C_PORT_SELECTED
 // these pins are supported by the ADC board:
 #define I2C_SDA0_PIN 4


### PR DESCRIPTION
Allow a contributor / designer to select a different default i2c port

Current code sets it in .c file. If contributor used (me :) ) uses different i2c port, needs to be careful each time when creating pull request. To not override the project default.

Actions taken:
In cmake file, check if user has set the environment variable I2C_PORT_SELECTED
if yes, pass it on to gcc toolchain as define

```
# if environment variable I2C_PORT_SELECTED declared, pass it on to the compiler
if(DEFINED ENV{I2C_PORT_SELECTED})
target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE I2C_PORT_SELECTED=$ENV{I2C_PORT_SELECTED})
endif()
```

If define detected, don't override but use it.
If define not detected, use existing project default value 1

```
// if the user did not set a selection, select I2C1 (shabaz solder instructions default)
#ifndef I2C_PORT_SELECTED
#define I2C_PORT_SELECTED 1
#endif // I2C_PORT_SELECTED
```
Tested, 

- without environment variable set: build uses existing default value 1
- with environment variable set (in OS environment, or in IDE settings): build uses value of that variable